### PR TITLE
Russel Pearson having problems w/ his github.io

### DIFF
--- a/_data/members.yml
+++ b/_data/members.yml
@@ -39,7 +39,7 @@ Instructors:
   - rdlee097.github.io/
   - micahm25.github.io/
   - alvinalmira.github.io
-  - rpearson808.github.io/
+ # - rpearson808.github.io/
   - yli7311.github.io/
   - riverss808.github.io
   - britniej.github.io/


### PR DESCRIPTION
* Changed line 42 to  # - rpearson808.github.io/

So the reason I'm doing this is because I'm currently having problems with my techfolio page -- namely, the essays are not updating on my page and I am stuck with the default example one from the template, so I'm worried that I might not be able to add any future essays to my profile.  I've also been getting YAML syntax errors from Github whenever I've been committing changes to my bio.json file despite not changing anything in terms of structure from the template bio.json file, which I have a feeling is the reason why I've been having problems with changes to the essay not being reflected on my profile.  I e-mailed Professor Kazman this morning and called him earlier today about this and he has not gotten back to me yet, and I want to make sure I am getting proper credit since I have completed the assignment as instructed outside of this issue.