### PR TITLE
Update members.yml

### DIFF
--- a/_data/members.yml
+++ b/_data/members.yml
@@ -11,11 +11,11 @@ TAs:
 #
 # Students here
 "Spring 2022 Students":
+  - anthonywonjoon.github.io/
 #
 "Fall 2021 Students":
   - adenmolina.github.io/
   - alyssia-chen.github.io/
-  - anthonywonjoon.github.io/
   - brandonjude.github.io
   - chloekamm.github.io/
   - claysedgwick.github.io/


### PR DESCRIPTION
remove OLD anthonywonjoon.github.io/ from Fall 2021 Students and add UPDATED anthonywonjoon.github.io/ to Spring 2022